### PR TITLE
 #48 : Check if the input element supports selection

### DIFF
--- a/modules/templateRenderer.js
+++ b/modules/templateRenderer.js
@@ -175,7 +175,7 @@
         currentCaret = this.getCaretPosition(activeElement);
       }
       this.hotswap(currentNode, newNode, ignoreElements);
-      if (activeElement) {
+      if (activeElement && this.supportsSelection(activeElement)) {
         this.setCaretPosition(activeElement, currentCaret);
       }
     },

--- a/modules/templateRenderer.js
+++ b/modules/templateRenderer.js
@@ -171,7 +171,7 @@
     hotswapKeepCaret: function(currentNode, newNode, ignoreElements) {
       var currentCaret,
           activeElement = document.activeElement;
-      if (activeElement && activeElement.hasAttribute('value')) {
+      if (activeElement && activeElement.hasAttribute('value') && this.supportsSelection(activeElement)) {
         currentCaret = this.getCaretPosition(activeElement);
       }
       this.hotswap(currentNode, newNode, ignoreElements);
@@ -195,6 +195,17 @@
         newDOM.setAttribute(attrib.name, attrib.value);
       });
       return newDOM;
+    },
+    
+    /** 
+     * Determines if the element supports selection. As per spec, https://html.spec.whatwg.org/multipage/forms.html#do-not-apply
+     * selection is only allowed for text, search, tel, url, password. Other input types will throw an exception in chrome
+     * @param el {Element} the DOM element to check 
+     * @return {Boolean} boolean indicating whether or not the selection is allowed for {Element} el 
+     * @method supportsSelection
+     */
+    supportsSelection : function (el) {
+      return (/text|password|search|tel|url/).test(el.type); 
     },
 
     /**


### PR DESCRIPTION
As Per this spec, https://html.spec.whatwg.org/multipage/forms.html#do-not-apply,
selection is only supported for input of type text, search, tel, url, password.
This commit adds a check to see if the element supports selection