### PR TITLE
add appveyor config file

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,32 @@
+# http://www.appveyor.com/docs/appveyor-yml
+
+# Fix line endings in Windows. (runs before repo cloning)
+init:
+  - git config --global core.autocrlf true
+
+# Test against these versions of Node.js.
+environment:
+  matrix:
+    - nodejs_version: "0.12"
+
+install:
+  # Get the latest stable version of Node 0.STABLE.latest
+  - ps: Install-Product node $env:nodejs_version
+  # Typical npm stuff.
+  - md C:\nc
+  - npm install -g npm@^2
+  # hide python so node-gyp won't try to build native extentions
+  # rename C:\Python27 Python27hidden
+  # Workaround https://github.com/npm/npm/wiki/Troubleshooting#upgrading-on-windows
+  - set PATH=%APPDATA%\npm;%PATH%
+  - npm config set cache C:\nc
+  - npm version
+  - npm install
+
+test_script:
+  # Output useful info for debugging.
+  - npm version
+  - cmd: npm run test
+
+version: "{build}"
+


### PR DESCRIPTION
Appveyor will build on Windows. Torso currently fails to build on Windows. Hoping this can increase visibility and, once we get the build passing, keep it passing.