### PR TITLE
getting hotswapKeepCaret to work with IE & iFrames

### DIFF
--- a/modules/templateRenderer.js
+++ b/modules/templateRenderer.js
@@ -182,6 +182,9 @@
       } catch (error) {
         activeElement = null;
       }
+      if (activeElement && this.supportsSelection(activeElement)) {
+        currentCaret = this.getCaretPosition(activeElement);
+      }
       this.hotswap(currentNode, newNode, ignoreElements);
       if (activeElement && this.supportsSelection(activeElement)) {
         this.setCaretPosition(activeElement, currentCaret);

--- a/modules/templateRenderer.js
+++ b/modules/templateRenderer.js
@@ -176,9 +176,11 @@
 
     hotswapKeepCaret: function(currentNode, newNode, ignoreElements) {
       var currentCaret,
-          activeElement = document.activeElement;
-      if (activeElement && this.supportsSelection(activeElement)) {
-        currentCaret = this.getCaretPosition(activeElement);
+          activeElement;
+      try {
+        activeElement = document.activeElement;
+      } catch (error) {
+        activeElement = null;
       }
       this.hotswap(currentNode, newNode, ignoreElements);
       if (activeElement && this.supportsSelection(activeElement)) {


### PR DESCRIPTION
document.activeElement doesn't play well with IE & iFrames, so we need to wrap it in a try/catch.  See issue #219 