### PR TITLE
Adding configuration for consistent releases using release-it

### DIFF
--- a/.release.json
+++ b/.release.json
@@ -1,0 +1,42 @@
+{
+    "non-interactive": false,
+    "dry-run": false,
+    "verbose": false,
+    "force": false,
+    "pkgFiles": ["package.json"],
+    "increment": "patch",
+    "prereleaseId": null,
+    "commitMessage": "Release v%s",
+    "tagName": "v%s",
+    "tagAnnotation": "Release v%s",
+    "buildCommand": false,
+    "changelogCommand": "git log --pretty=format:'* v%s (%h)' [REV_RANGE]",
+    "requireCleanWorkingDir": false,
+    "src": {
+        "pushRepo": null,
+        "beforeStartCommand": false,
+        "beforeStageCommand": false,
+        "afterReleaseCommand": false
+    },
+    "dist": {
+        "repo": false,
+        "stageDir": ".stage",
+        "baseDir": "dist",
+        "files": ["**/*"],
+        "pkgFiles": null,
+        "beforeStageCommand": false,
+        "afterReleaseCommand": false
+    },
+    "npm": {
+        "publish": true,
+        "publishPath": ".",
+        "tag": "latest",
+        "private": false,
+        "forcePublishSourceRepo": false
+    },
+    "github": {
+        "release": true,
+        "releaseName": "v%s",
+        "tokenRef": "GITHUB_TOKEN"
+    }
+}

--- a/.release.json
+++ b/.release.json
@@ -10,7 +10,7 @@
     "tagName": "v%s",
     "tagAnnotation": "Release v%s",
     "buildCommand": false,
-    "changelogCommand": "git log --pretty=format:'* v%s (%h)' [REV_RANGE]",
+    "changelogCommand": "git log --pretty=format:'* %s (%h)' [REV_RANGE]",
     "requireCleanWorkingDir": false,
     "src": {
         "pushRepo": null,

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -86,3 +86,13 @@ instead of
 ```
 gulp
 ```
+
+### Release Commands:
+Run once to install release-it:
+```
+npm install release-it -g
+```
+Then when you want to release run this (run from the upstream repo, i.e. the one directly from vecnatechnologies, not your fork).  You will need appropritate rights to push.
+```
+release-it
+```


### PR DESCRIPTION
https://github.com/webpro/release-it

This was the config I used to release v0.6.5 (mainly updated to add v to the beginning of the release number).  
It also creates the release in github and initially populates it with each commit message.