### PR TITLE
Ref #241: Change libraries to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,14 +17,17 @@
     "clean": "gulp clean"
   },
   "main": "modules/torso.js",
+  "peerDependencies": {
+    "jquery": "2.1.x",
+    "backbone": "1.2.x",
+    "underscore": "1.8.x"
+  },
   "dependencies": {
-    "jquery": "2.1.3",
-    "underscore": "1.8.2",
-    "backbone": "1.2.3",
     "backbone-nested": "2.0.4",
     "backbone.stickit": "0.9.2"
   },
   "devDependencies": {
+    "backbone": "1.2.3",
     "browserify": "^12.0.2",
     "del": "^1.1.1",
     "gulp": "^3.8.8",
@@ -46,6 +49,7 @@
     "jasmine-core": "^2.4.1",
     "jasmine-reporters": "2.0.2",
     "jasmine-spec-reporter": "2.1.0",
+    "jquery": "2.1.3",
     "jquery-mockjax": "1.6.1",
     "jsdom": "3.0.2",
     "jshint-stylish": "^1.0.1",
@@ -63,6 +67,7 @@
     "promise": "6.1.0",
     "require-dir": "^0.1.0",
     "requireify": "^0.2.1",
+    "underscore": "1.8.2",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.0.0",
     "watchify": "^3.7.0",


### PR DESCRIPTION
I think this will work, but I'm not sure how to test it properly without releasing a package. I've duplicated peerDependencies in devDependencies for future-compatibility should we switch to npm > 3.