### PR TITLE
Add a retrieve promise to DataBehavior

### DIFF
--- a/modules/Behavior.js
+++ b/modules/Behavior.js
@@ -18,7 +18,7 @@
     'before-detached-callback':  '_detached',
     'before-activate-callback': '_activate',
     'before-deactivate-callback': '_deactivate',
-    'before-dispose-callback': '_dispose',
+    'before-dispose-callback': 'dispose',
     'render:before-attach-tracked-views': 'attachTrackedViews',
     'render:begin': 'prerender',
     'render:complete': 'postrender',
@@ -125,7 +125,7 @@
      */
     __bindLifecycleMethods: function() {
       this.listenTo(this.view, 'initialize:complete', this.__augmentViewPrepare);
-      this.listenTo(this.view, 'before-dispose-callback', this.__dispose);
+      this.listenTo(this.view, 'before-dispose-callback', this.dispose);
       _.each(eventMap, function(callback, event) {
         this.listenTo(this.view, event, this[callback]);
       }, this);
@@ -201,15 +201,36 @@
     },
 
     /**
-     * Preforms basic cleanup of a behavior before specific cleanup by extensions.
-     * @method __dispose
-     * @private
+     * Removes all listeners, stops listening to events.
+     * After dispose is called, the behavior can be safely garbage collected.
+     * Called when the owning view is disposed.
+     * @method _dispose
      */
-    __dispose: function() {
+    dispose: function() {
+      this.trigger('before-dispose-callback');
+      this._dispose();
+
       this.stopListening();
       this.off();
-    }
 
+      this.__isDisposed = true;
+    },
+
+    /**
+     * Method to be invoked when dispose is called. By default calling dispose will remove the
+     * view's on's and listenTo's.
+     * Override this method to destruct any extra
+     * @method _dispose
+     */
+    _dispose: _.noop,
+
+    /**
+     * @return {Boolean} true if the view was disposed
+     * @method isDisposed
+     */
+    isDisposed: function() {
+      return this.__isDisposed;
+    }
   });
 
   return Behavior;

--- a/modules/Behavior.js
+++ b/modules/Behavior.js
@@ -216,7 +216,7 @@
 
     /**
      * Method to be invoked when dispose is called. By default calling dispose will remove the
-     * view's on's and listenTo's.
+     * behavior's on's and listenTo's.
      * Override this method to destruct any extra
      * @method _dispose
      */

--- a/modules/Behavior.js
+++ b/modules/Behavior.js
@@ -18,7 +18,7 @@
     'before-detached-callback':  '_detached',
     'before-activate-callback': '_activate',
     'before-deactivate-callback': '_deactivate',
-    'before-dispose-callback': 'dispose',
+    'before-dispose-callback': '_dispose',
     'render:before-attach-tracked-views': 'attachTrackedViews',
     'render:begin': 'prerender',
     'render:complete': 'postrender',
@@ -125,7 +125,7 @@
      */
     __bindLifecycleMethods: function() {
       this.listenTo(this.view, 'initialize:complete', this.__augmentViewPrepare);
-      this.listenTo(this.view, 'before-dispose-callback', this.dispose);
+      this.listenTo(this.view, 'before-dispose-callback', this.__dispose);
       _.each(eventMap, function(callback, event) {
         this.listenTo(this.view, event, this[callback]);
       }, this);
@@ -204,12 +204,10 @@
      * Removes all listeners, stops listening to events.
      * After dispose is called, the behavior can be safely garbage collected.
      * Called when the owning view is disposed.
-     * @method _dispose
+     * @method __dispose
      */
-    dispose: function() {
+    __dispose: function() {
       this.trigger('before-dispose-callback');
-      this._dispose();
-
       this.stopListening();
       this.off();
 

--- a/modules/behaviors/DataBehavior.js
+++ b/modules/behaviors/DataBehavior.js
@@ -273,6 +273,7 @@
           this.view.render();
         }
       });
+      this.listenTo(this.view, 'before-dispose-callback', this.data.dispose);
     },
 
     /**
@@ -895,16 +896,6 @@
       this.stopListeningToIdsPropertyChangeEvent();
       this._undelegateUpdateEvents();
       this.data.deactivate();
-    },
-
-    /**
-     * Default dispose stuff because its not already on behavior.  See https://github.com/vecnatechnologies/backbone-torso/issues/295
-     * @method _dispose
-     * @private
-     */
-    _dispose: function() {
-      Behavior.prototype._dispose.apply(this, arguments);
-      this.data.dispose();
     }
   });
 
@@ -940,6 +931,8 @@
        * @property privateCollection {Collection}
        */
       this.privateCollection = options.privateCollection;
+
+      _.bindAll(this, 'dispose');
     },
 
     /**

--- a/modules/behaviors/DataBehavior.js
+++ b/modules/behaviors/DataBehavior.js
@@ -408,6 +408,46 @@
     },
 
     /**
+     * This is a good way to have something be called after at least one retrieve (pull or fetch) has completed.
+     * This is especially useful if you don't care if the fetch has already happen you just want to do something once
+     * the data is loaded.
+     *
+     * This can also be done purely by listening for the 'fetched' event, but you might miss the event if it is fired
+     * before you start listening.  This gives a structure for handling that case so that your methods are called
+     * if the event is fired and if it is not fired.
+     *
+     * This also gives the ability to distinguish between a successful and failed fetch easily using the promises
+     * resolve/reject handlers.
+     *
+     * Usage:
+     *
+     * someDataBehavior.retrieveOncePromise()
+     *   .then(view.doSomethingWithTheData, view.handleFiledFetch);
+     *
+     * @method retrieveOncePromise
+     * @return {jQuery.Promise} that resolves when the data is successfully fetched and rejects when the fetch fails.
+     */
+    retrieveOncePromise: function() {
+      var retrieveOnceDeferred = $.Deferred();
+      var demographicsFetchSuccess = this.get('fetchSuccess');
+      if (demographicsFetchSuccess) {
+        retrieveOnceDeferred.resolve();
+      } else if (demographicsFetchSuccess === false) {
+        retrieveOnceDeferred.reject();
+      } else {
+        this.once('fetched', function() {
+          var demographicsFetchSuccess = this.get('fetchSuccess');
+          if (demographicsFetchSuccess) {
+            retrieveOnceDeferred.resolve();
+          } else {
+            retrieveOnceDeferred.reject();
+          }
+        });
+      }
+      return retrieveOnceDeferred.promise();
+    },
+
+    /**
      * Removes existing listeners and adds new ones for all of the updateEvents configured.
      * @method _delegateUpdateEvents
      * @private
@@ -760,6 +800,7 @@
      */
     __fetchSuccess: function(response) {
       this.set('fetchSuccess', true);
+      this.set('fetchedOnce', true);
       if (this.__shouldTriggerFetchedEvent(response)) {
         this.trigger('fetched', {
           status: FETCHED_STATUSES.SUCCESS,
@@ -778,13 +819,15 @@
     /**
      * Triggers a 'fetched' event with the payload { status: 'failed' } when the fetch fails.
      * @method __fetchFailed
-     * @param response {Object} the response from the server.
+     * @param [response] {Object} the response from the server.
      *   @param [response.skipObjectRetrieval=false] {Boolean} if we retrieved objects, then trigger fetch event.
      *   @param [response.forceFetchedEvent=false] {Boolean} if true then trigger fetch no matter what.
+     *   @param [response.emptyIds=false] {Boolean} true if were are no ids retrieved.  False otherwise.
      * @private
      */
     __fetchFailed: function(response) {
       this.set('fetchSuccess', false);
+      this.set('fetchedOnce', true);
       if (this.__shouldTriggerFetchedEvent(response)) {
         this.trigger('fetched', {
           status: FETCHED_STATUSES.FAILURE,
@@ -794,7 +837,7 @@
           status: FETCHED_STATUSES.FAILURE,
           response: response
         });
-        if (response.emptyIds) {
+        if (response && response.emptyIds) {
           this.__firstEmptyFetchedTriggered = true;
         }
       }

--- a/modules/behaviors/DataBehavior.js
+++ b/modules/behaviors/DataBehavior.js
@@ -903,6 +903,7 @@
      * @private
      */
     _dispose: function() {
+      Behavior.prototype._dispose.apply(this, arguments);
       this.data.dispose();
     }
   });

--- a/modules/behaviors/DataBehavior.js
+++ b/modules/behaviors/DataBehavior.js
@@ -904,9 +904,6 @@
      */
     _dispose: function() {
       this.data.dispose();
-
-      this.off();
-      this.stopListening();
     }
   });
 
@@ -1079,6 +1076,7 @@
     dispose: function() {
       this.off();
       this.stopListening();
+      this.privateCollection.dispose();
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "gulp-uglify": "^1.0.1",
     "gulp-util": "^3.0.1",
     "gulp-wrap": "0.9.0",
-    "handlebars": "3.0.0",
+    "handlebars": "^4.0.0",
     "hbsfy": "^2.6.0",
     "jasmine": "2.5.3",
     "jasmine-core": "^2.4.1",

--- a/test/karma/behaviorSpec.js
+++ b/test/karma/behaviorSpec.js
@@ -711,10 +711,10 @@ describe('A Torso Behavior', function() {
       expect(methodsCalled[1]).toBe('view:_deactivate');
     });
 
-    it('dispose is called when view is disposed', function() {
+    it('_dispose and __dispose are called when view is disposed', function() {
       var BehaviorTrackingDispose = TorsoBehavior.extend({
         constructor: function() {
-          spyOn(this, 'dispose').and.callThrough();
+          spyOn(this, '__dispose').and.callThrough();
           TorsoBehavior.prototype.constructor.apply(this, arguments);
         }
       });
@@ -723,27 +723,20 @@ describe('A Torso Behavior', function() {
           behaviorTrackingDispose: {
             behavior: BehaviorTrackingDispose
           }
-        },
-        constructor: function() {
-          spyOn(this, 'dispose').and.callThrough();
-          TorsoView.prototype.constructor.apply(this, arguments);
         }
       });
       var viewTrackingDispose = new ViewTrackingDispose();
       var behaviorTrackingDispose = viewTrackingDispose.getBehavior('behaviorTrackingDispose');
-      expect(behaviorTrackingDispose.dispose).not.toHaveBeenCalled();
+      expect(behaviorTrackingDispose.__dispose).not.toHaveBeenCalled();
 
       viewTrackingDispose.dispose();
 
-      expect(behaviorTrackingDispose.dispose).toHaveBeenCalled();
+      expect(behaviorTrackingDispose.__dispose).toHaveBeenCalled();
     });
 
     it('calls _dispose when dispose is called', function() {
       var BehaviorTrackingDispose = TorsoBehavior.extend({
-        constructor: function() {
-          spyOn(this, '_dispose').and.callThrough();
-          TorsoBehavior.prototype.constructor.apply(this, arguments);
-        }
+        _dispose: jasmine.createSpy('behavior._dispose')
       });
       var behaviorTrackingDispose = new BehaviorTrackingDispose(null, {
         alias: 'trackingDispose',
@@ -751,7 +744,7 @@ describe('A Torso Behavior', function() {
       });
       expect(behaviorTrackingDispose._dispose).not.toHaveBeenCalled();
 
-      behaviorTrackingDispose.dispose();
+      behaviorTrackingDispose.view.dispose();
 
       expect(behaviorTrackingDispose._dispose).toHaveBeenCalled();
     });
@@ -775,7 +768,7 @@ describe('A Torso Behavior', function() {
       behaviorTrackingDispose._eventHandler.calls.reset();
       expect(behaviorTrackingDispose._eventHandler).not.toHaveBeenCalled();
 
-      behaviorTrackingDispose.dispose();
+      behaviorTrackingDispose.view.dispose();
 
       expect(behaviorTrackingDispose._eventHandler).not.toHaveBeenCalled();
       behaviorTrackingDispose.trigger(eventName);
@@ -802,7 +795,7 @@ describe('A Torso Behavior', function() {
       behaviorTrackingDispose._eventHandler.calls.reset();
       expect(behaviorTrackingDispose._eventHandler).not.toHaveBeenCalled();
 
-      behaviorTrackingDispose.dispose();
+      behaviorTrackingDispose.view.dispose();
 
       expect(behaviorTrackingDispose._eventHandler).not.toHaveBeenCalled();
       eventSource.trigger(eventName);

--- a/test/karma/dataBehaviorSpec.js
+++ b/test/karma/dataBehaviorSpec.js
@@ -3136,7 +3136,7 @@ ids = []\n\
     spyOn(behavior.data.privateCollection, 'dispose');
 
     expect(behavior.data.privateCollection.dispose).not.toHaveBeenCalled();
-    behavior.dispose();
+    behavior.view.dispose();
 
     expect(behavior.data.privateCollection.dispose).toHaveBeenCalled();
   });

--- a/test/karma/dataBehaviorSpec.js
+++ b/test/karma/dataBehaviorSpec.js
@@ -58,6 +58,14 @@ var ViewWithDataBehavior = TorsoView.extend({
     dataBehavior: getBasicBehaviorConfiguration()
   }
 });
+function getBasicBehaviorInstance() {
+  return new TorsoDataBehavior(null, {
+    alias: 'basicBehavior',
+    view: new TorsoView(),
+    cache: new TorsoTestCacheCollection(),
+    ids: [1, 2]
+  });
+}
 
 describe('A Torso Data Behavior', function() {
 
@@ -3075,5 +3083,51 @@ ids = []\n\
         fail(error);
         done();
       });
+  });
+
+  it('will resolve the retrieveOncePromise if the fetch status is already successful', function(done) {
+    var behavior = getBasicBehaviorInstance();
+    behavior.set('fetchSuccess', true);
+
+    behavior.retrieveOncePromise()
+      .then(_.noop, function() {
+        fail('the promise should be resolved, not rejected')
+      })
+      .then(done, done);
+  });
+
+  it('will reject the retrieveOncePromise if the fetch status is already failed', function(done) {
+    var behavior = getBasicBehaviorInstance();
+    behavior.set('fetchSuccess', false);
+
+    behavior.retrieveOncePromise()
+      .then(function() {
+        fail('the promise should be rejected, not resolved')
+      })
+      .then(done, done);
+  });
+
+  it('will resolve the retrieveOncePromise when the fetch completes successfully', function(done) {
+    var behavior = getBasicBehaviorInstance();
+
+    behavior.retrieveOncePromise()
+      .then(_.noop, function() {
+        fail('the promise should be resolved, not rejected')
+      })
+      .then(done, done);
+
+    behavior.__fetchSuccess();
+  });
+
+  it('will reject the retrieveOncePromise when the fetch fails', function(done) {
+    var behavior = getBasicBehaviorInstance();
+
+    behavior.retrieveOncePromise()
+      .then(function() {
+        fail('the promise should be rejected, not resolved')
+      })
+      .then(done, done);
+
+    behavior.__fetchFailed();
   });
 });

--- a/test/karma/dataBehaviorSpec.js
+++ b/test/karma/dataBehaviorSpec.js
@@ -3123,11 +3123,21 @@ ids = []\n\
     var behavior = getBasicBehaviorInstance();
 
     behavior.retrieveOncePromise()
-      .then(function() {
+      .then(function () {
         fail('the promise should be rejected, not resolved')
       })
       .then(done, done);
 
     behavior.__fetchFailed();
+  });
+
+  it('will dispose of the private collection of the data behavior when the data behavior is disposed', function() {
+    var behavior = getBasicBehaviorInstance();
+    spyOn(behavior.data.privateCollection, 'dispose');
+
+    expect(behavior.data.privateCollection.dispose).not.toHaveBeenCalled();
+    behavior.dispose();
+
+    expect(behavior.data.privateCollection.dispose).toHaveBeenCalled();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -211,7 +211,7 @@ async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
 
-async@^1.2.1:
+async@^1.2.1, async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
@@ -1917,15 +1917,6 @@ gulplog@^1.0.0:
   dependencies:
     glogg "^1.0.0"
 
-handlebars@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-3.0.0.tgz#7f4e537f4dd6992869d66c01b7505eba3561a5d5"
-  dependencies:
-    optimist "^0.6.1"
-    source-map "^0.1.40"
-  optionalDependencies:
-    uglify-js "~2.3"
-
 handlebars@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-2.0.0.tgz#6e9d7f8514a3467fa5e9f82cc158ecfc1d5ac76f"
@@ -1933,6 +1924,16 @@ handlebars@^2.0.0:
     optimist "~0.3"
   optionalDependencies:
     uglify-js "~2.3"
+
+handlebars@^4.0.0:
+  version "4.0.11"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.11.tgz#630a35dfe0294bc281edae6ffc5d329fc7982dcc"
+  dependencies:
+    async "^1.4.0"
+    optimist "^0.6.1"
+    source-map "^0.4.4"
+  optionalDependencies:
+    uglify-js "^2.6"
 
 har-schema@^1.0.5:
   version "1.0.5"
@@ -3871,9 +3872,15 @@ source-map@0.X, "source-map@>= 0.1.2", source-map@^0.5.1, source-map@^0.5.3, sou
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
-source-map@^0.1.38, source-map@^0.1.40, source-map@~0.1.25, source-map@~0.1.27, source-map@~0.1.7:
+source-map@^0.1.38, source-map@~0.1.25, source-map@~0.1.27, source-map@~0.1.7:
   version "0.1.43"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
+  dependencies:
+    amdefine ">=0.0.4"
+
+source-map@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
   dependencies:
     amdefine ">=0.0.4"
 
@@ -4178,6 +4185,15 @@ uglify-js@2.6.4:
     source-map "~0.5.1"
     uglify-to-browserify "~1.0.0"
     yargs "~3.10.0"
+
+uglify-js@^2.6:
+  version "2.8.29"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
+  dependencies:
+    source-map "~0.5.1"
+    yargs "~3.10.0"
+  optionalDependencies:
+    uglify-to-browserify "~1.0.0"
 
 uglify-js@~2.3:
   version "2.3.6"


### PR DESCRIPTION
* The goal is to have a promise that resolves/rejects immediately if
the behavior has already retrieved data or waits until the next fetch
completes before resolving or rejecting.  Resolving or rejecting is
based on the success/failure result of the fetch.